### PR TITLE
Add a Service resource to expose webgoat

### DIFF
--- a/webgoat.yaml
+++ b/webgoat.yaml
@@ -19,3 +19,16 @@ spec:
           name: webgoat
           ports: 
           - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: webgoat-service
+  namespace: default
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    app: webgoat


### PR DESCRIPTION
Adds a Service resource to webgoat.yaml, which will expose WebGoat on port 80 and on public IP address.

Run `kubectl get services` to display the public IP address. Access WebGoat via '<<public-IP>>/WebGoat'