### PR TITLE
Adding a Kube Spec for Terracotta Bank

### DIFF
--- a/apps/terracotta-bank.yaml
+++ b/apps/terracotta-bank.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: terracotta-bank
+  namespace: default
+  labels:
+    contrast: java-assess
+spec:
+  selector:
+    matchLabels:
+      app: terracotta-bank
+  template:
+    metadata:
+      labels:
+        app: terracotta-bank
+    spec:
+      containers:
+        - image: contrastsecuritydemo/terracotta-bank:3.0-no-agent
+          name: terracotta-bank
+          ports: 
+          - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: terracotta-bank-service
+  namespace: default
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    app: terracotta-bank


### PR DESCRIPTION
* Updated the Docker image in demo-terracotta-bank to a new multistage build
* Pushed a version of the docker image to hub WITHOUT the contrast agent to avoid this: 
```The Contrast Agent is already attached, verify that your VM arguments don't include `-javaagent` twice for the Contrast Agent.```
* Tested with the Contrast Agent operator